### PR TITLE
Fixes #17 grammatical error in status

### DIFF
--- a/immersive-web-wg-charter.html
+++ b/immersive-web-wg-charter.html
@@ -92,7 +92,7 @@
       </h1>
       <p>
         <em>Status: this is a draft charter for a possible W3C Immersive Web Working
-        Group charter provided for discussion, without any formal
+        Group, provided for discussion, without any formal
         standing.</em>
       </p>
       <p class="mission">


### PR DESCRIPTION
Removes the second instance of "charter" from the opening status paragraph.