### PR TITLE
change name of Navigation id to deal with definition in pubrules

### DIFF
--- a/immersive-web-wg-charter.html
+++ b/immersive-web-wg-charter.html
@@ -323,7 +323,7 @@
             <dd>
               <p>This feature would provide depth and occlusion data on AR devices.</p>
             </dd>
-            <dt id="navigation" class="spec">Navigation</dt>
+            <dt id="spec-navigation" class="spec">Navigation</dt>
             <dd>
               <p>This feature would enable better control of  experiences when users navigate from one XR experience to another.</p>
             </dd>


### PR DESCRIPTION
ID 'navigation' is used for styling in pubrules CSS file, and changed the ID with adding 'spec-' prefix to fix it.