### PR TITLE
updated 2022 draft charter for IPP links and /TR/ links

### DIFF
--- a/immersive-web-wg-charter.html
+++ b/immersive-web-wg-charter.html
@@ -339,7 +339,7 @@
         <dl>
 
           <dt id="webxr-dom-overlays" class="spec"><a href="https://immersive-web.github.io/dom-overlays/"
-              target="_blank">DOM Overlays Module</a></dt>
+              target="_blank">WebXR DOM Overlays Module</a></dt>
           <dd>
             <p>This specification defines a mechanism for showing interactive 2D web content during an immersive WebXR
               session.</p>
@@ -355,7 +355,7 @@
           </dd>
 
           <dt id="webxr-lighting-estimation" class="spec"><a href="https://immersive-web.github.io/lighting-estimation/"
-              target="_blank">WebXR Lighting Estimation Module</a></dt>
+              target="_blank">WebXR Lighting Estimation API Level 1</a></dt>
           <dd>
             <p>This specification enables developers to render augmented reality content that reacts to real world
               lighting with the WebXR Device API and the WebXR AR Module.</p>
@@ -369,7 +369,7 @@
           </dd>
 
           <dt id="webxr-hand-input" class="spec"><a href="https://immersive-web.github.io/webxr-hand-input/"
-              target="_blank">WebXR Hand Input Module</a></dt>
+              target="_blank">WebXR Hand Input Module - Level 1</a></dt>
           <dd>
             <p>This specification defines a method for enabling hand input to be used with the WebXR Device API.</p>
             <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webxr-hand-input-1/"
@@ -398,8 +398,7 @@
                 Immersive Web CG</a></p>
           </dd>
 
-          <dt id="webxr-hit-test" class="spec"><a href="https://immersive-web.github.io/layers/" target="_blank">WebXR
-              Layers API</a></dt>
+          <dt id="webxr-hit-test" class="spec"><a href="https://immersive-web.github.io/layers/" target="_blank">WebXR Layers API Level 1</a></dt>
           <dd>
             <p>This specification defines methods for manipulating composition layers used with the WebXR Device API.
             </p>
@@ -416,8 +415,7 @@
         </dl>
 
         <dl>
-          <dt id="raw-camera-access" class="spec"><a href="https://immersive-web.github.io/raw-camera-access/">Raw
-              Camera Access</a></dt>
+          <dt id="raw-camera-access" class="spec"><a href="https://immersive-web.github.io/raw-camera-access/">WebXR Raw Camera Access Module</a></dt>
           <dd>
             <p>This feature would enable predictable access to camera frame data for AR devices.</p>
             <p class="draft-status"><b>Draft state:</b> Adopted from <a href="https://www.w3.org/community/immersive-web/">the Immersive Web CG</a></p>

--- a/immersive-web-wg-charter.html
+++ b/immersive-web-wg-charter.html
@@ -253,7 +253,7 @@
               changes.</p>
             <p>This specification defines support for accessing virtual reality (VR) and augmented reality (AR) devices,
               including sensors and head-mounted displays, on the Web.</p>
-            <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/standards/types#ED"
+            <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webxr/"
                 target="_blank">Working Draft</a></p>
             <p class="milestone todo"><b>Expected completion:</b> <i>Q2 2022</i></p>
             <p><b>Adopted Working Draft:</b> <a href="https://www.w3.org/TR/2021/WD-webxr-20211026/"
@@ -276,7 +276,8 @@
               changes.</p>
             <p>This specification defines support for accessing button, trigger, thumbstick, and touchpad data
               associated with virtual reality (VR) and augmented reality (AR) devices on the Web.</p>
-            <p class="draft-status"><b>Draft state:</b> Working Draft</p>
+            <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webxr-gamepads-module-1/"
+              target="_blank">Working Draft</a></p>
             <p class="milestone todo"><b>Expected completion:</b> <i>Q4 2022</i></p>
             <p><b>Adopted Working Draft:</b> <a href="https://www.w3.org/TR/2021/WD-webxr-gamepads-module-1-20210824/"
                 target="_blank">WebXR Gamepads
@@ -299,7 +300,8 @@
               substantial changes.</p>
             <p>This specification defines an expansion module of the WebXR Device API with the functionality available
               on AR hardware.</p>
-            <p class="draft-status"><b>Draft state:</b> Working Draft</p>
+            <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webxr-ar-module-1/"
+              target="_blank">Working Draft</a></p>
             <p class="milestone todo"><b>Expected completion:</b> <i>Q2 2024</i></p>
             <p><b>Adopted Working Draft:</b> <a href="https://www.w3.org/TR/2021/WD-webxr-ar-module-1-20210824/"
                 target="_blank">WebXR
@@ -321,12 +323,13 @@
               changes.</p>
             <p>This specification defines a method for performing hit tests against real world geometry to be used with
               the WebXR Device API.</p>
-            <p class="draft-status"><b>Draft state:</b> Working Draft</p>
+            <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webxr-hit-test-1/"
+              target="_blank">Working Draft</a></p>
             <p class="milestone todo"><b>Expected completion:</b> <i>Q2 2024</i></p>
             <p><b>Adopted Working Draft:</b> <a href="https://www.w3.org/TR/2021/WD-webxr-hit-test-1-20210831/"
                 target="_blank">WebXR
                 Hit Test
-                Module</a>(31 August 2021)</p>
+                Module</a> (31 August 2021)</p>
             <p>Exclusion Draft:
               <a href='https://www.w3.org/TR/2021/WD-webxr-hit-test-1-20210831/'>https://www.w3.org/TR/2021/WD-webxr-hit-test-1-20210831/</a><br>
               associated <a href='https://www.w3.org/mid/cfe-8519-04be7f101f94882ce9ad5bbb5fbcd94ee7315b1c@w3.org'> Call for Exclusion</a> on 2021-08-31 ended on 2022-01-28</p>
@@ -340,11 +343,12 @@
           <dd>
             <p>This specification defines a mechanism for showing interactive 2D web content during an immersive WebXR
               session.</p>
-            <p class="draft-status"><b>Draft state:</b> Working Draft</p>
+            <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webxr-dom-overlays-1/"
+              target="_blank">Working Draft</a></p>
             <p class="milestone todo"><b>Expected completion:</b> <i>Q4 2024</i></p>
             <p><b>Adopted Working Draft:</b> <a href="https://www.w3.org/TR/2021/WD-webxr-dom-overlays-1-20210831/"
                 target="_blank">WebXR DOM Overlays
-                Module</a>(31 August 2021)</p>
+                Module</a> (31 August 2021)</p>
             <p>Exclusion Draft:
               <a href='https://www.w3.org/TR/2021/WD-webxr-dom-overlays-1-20210831/'>https://www.w3.org/TR/2021/WD-webxr-dom-overlays-1-20210831/</a><br>
               associated <a href='https://www.w3.org/mid/cfe-8520-c287850e7931cbfa0340f98bf88914a3e09eb696@w3.org'> Call for Exclusion</a> on 2021-08-31 ended on 2022-01-28</p>
@@ -355,11 +359,10 @@
           <dd>
             <p>This specification enables developers to render augmented reality content that reacts to real world
               lighting with the WebXR Device API and the WebXR AR Module.</p>
-            <p class="draft-status"><b>Draft state:</b> Working Draft</p>
+            <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webxr-lighting-estimation-1/" target="_blank">Working Draft</a></p>
             <p class="milestone todo"><b>Expected completion:</b> <i>Q4 2024</i></p>
             <p><b>Adopted Working Draft:</b> <a
-                href="https://www.w3.org/TR/2021/WD-webxr-lighting-estimation-1-20210909/" target="_blank">WebXR
-                Lighting Estimation Proposal</a>(9 September 2021)</p>
+                href="https://www.w3.org/TR/2021/WD-webxr-lighting-estimation-1-20210909/" target="_blank">WebXR Lighting Estimation API Level 1</a> (9 September 2021)</p>
             <p>Exclusion Draft:
               <a href='https://www.w3.org/TR/2021/WD-webxr-lighting-estimation-1-20210909/'>https://www.w3.org/TR/2021/WD-webxr-lighting-estimation-1-20210909/</a><br>
               associated <a href='https://www.w3.org/mid/cfe-8571-aa44fe0b1d0076df4a491deb7d06b0049d243f3f@w3.org'> Call for Exclusion</a> on 2021-09-09 ended on 2022-02-06</i></p>
@@ -369,11 +372,11 @@
               target="_blank">WebXR Hand Input Module</a></dt>
           <dd>
             <p>This specification defines a method for enabling hand input to be used with the WebXR Device API.</p>
-            <p class="draft-status"><b>Draft state:</b> Working Draft</p>
+            <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webxr-hand-input-1/"
+              target="_blank">Working Draft</a></p>
             <p class="milestone todo"><b>Expected completion:</b> <i>Q4 2024</i></p>
             <p><b>Adopted Working Draft:</b> <a href="https://www.w3.org/TR/2021/WD-webxr-hand-input-1-20210824/"
-                target="_blank">WebXR Hand
-                Input Proposal</a></p>
+                target="_blank">WebXR Hand Input Module - Level 1</a> (24 August 2021)</p>
             <p>Exclusion Draft:
               <a href='https://www.w3.org/TR/2020/WD-webxr-hand-input-1-20201022/'>https://www.w3.org/TR/2020/WD-webxr-hand-input-1-20201022/</a><br>
               associated <a href='https://www.w3.org/mid/cfe-7623-ef016e129bceabf9aa2b7558bda7d0ce303bde86@w3.org'> Call for Exclusion</a> on 2020-10-22 ended on 2021-03-21</p>
@@ -389,22 +392,22 @@
               that need to be updated to correctly reflect the evolving understanding of the world, such that the poses
               remain aligned with the same place in the physical world. These poses will persist inside sessions, but
               not across sessions.</p>
-            <p class="draft-status"><b>Draft state:</b> Working Draft</p>
+            <p class="draft-status"><b>Draft state:</b> <a href="https://immersive-web.github.io/anchors/">Editor's Draft</a></p>
             <p class="milestone todo"><b>Expected completion:</b> <i>Q2 2022</i></p>
             <p><b>Adopted Working Draft:</b> Adopted from <a href="https://www.w3.org/community/immersive-web/">the
                 Immersive Web CG</a></p>
           </dd>
 
           <dt id="webxr-hit-test" class="spec"><a href="https://immersive-web.github.io/layers/" target="_blank">WebXR
-              Layers API Level 1</a></dt>
+              Layers API</a></dt>
           <dd>
             <p>This specification defines methods for manipulating composition layers used with the WebXR Device API.
             </p>
-            <p class="draft-status"><b>Draft state:</b> Working Draft</p>
+            <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webxrlayers-1/"
+              target="_blank">Working Draft</a></p>
             <p class="milestone"><b>Expected completion:</b> <i>Q2 2022</i></p>
             <p><b>Adopted Working Draft:</b> <a href="https://www.w3.org/TR/2021/WD-webxrlayers-1-20211207/"
-                target="_blank">WebXR
-                Layers Proposal</a>
+                target="_blank">WebXR Layers API Level 1</a> (7 December 2021)
             </p>
             <p>Exclusion Draft:
               <a href='https://www.w3.org/TR/2020/WD-webxrlayers-1-20201203/'>https://www.w3.org/TR/2020/WD-webxrlayers-1-20201203/</a><br>
@@ -417,7 +420,7 @@
               Camera Access</a></dt>
           <dd>
             <p>This feature would enable predictable access to camera frame data for AR devices.</p>
-            <p class="draft-status"><b>Draft state:</b> Adopted from the Immersive Web CG</p>
+            <p class="draft-status"><b>Draft state:</b> Adopted from <a href="https://www.w3.org/community/immersive-web/">the Immersive Web CG</a></p>
             <p class="milestone todo"><b>Expected completion:</b> <i>Q4 2023</i></p>
             <p><b>Adopted Working Draft:</b> Adopted from <a
                 href="https://immersive-web.github.io/raw-camera-access/">the
@@ -428,10 +431,10 @@
               API</a></dt>
           <dd>
             <p>This feature would provide depth and occlusion data on AR devices.</p>
-            <p class="draft-status"><b>Draft state:</b> Working Draft</p>
+            <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/webxr-depth-sensing-1/">Working Draft</a></p>
             <p class="milestone todo"><b>Expected completion:</b> <i>Q4 2023</i></p>
             <p><b>Adopted Working Draft:</b> <a
-                href="https://www.w3.org/TR/2021/WD-webxr-depth-sensing-1-20210831/">WebXR Depth Sensing Module</a></p>
+                href="https://www.w3.org/TR/2021/WD-webxr-depth-sensing-1-20210831/">WebXR Depth Sensing Module</a> (31 August 2021)</p>
             <p>Exclusion Draft:
               <a href='https://www.w3.org/TR/2021/WD-webxr-depth-sensing-1-20210831/'>https://www.w3.org/TR/2021/WD-webxr-depth-sensing-1-20210831/</a><br>
               associated <a href='https://www.w3.org/mid/cfe-8518-b1a8b62d07dce7e017068baaa2fb901082738934@w3.org'> Call for Exclusion</a> on 2021-08-31 ended on 2022-01-28</p>
@@ -442,23 +445,23 @@
           <dd>
             <p>This feature would enable better control of experiences when users navigate from one XR experience to
               another.</p>
-
-            <p class="draft-status"><b>Draft state:</b> Adopted from the Immersive Web CG</p>
+            <p class="draft-status"><b>Draft state:</b> Adopted from <a href="https://www.w3.org/community/immersive-web/">the Immersive Web CG</a></p>
             <p class="milestone todo"><b>Expected completion:</b> <i>Q4 2023</i></p>
+            <p><b>Adopted Working Draft:</b> Adopted from <a href="https://github.com/immersive-web/navigation">the Immersive Web CG</a></p>
+          </dd>
+        </dl>
 
+          <p>
+            The Working Group also intends to work on the following Recommendation-Track deliverables, although it
+            recognizes these
+            Recommendations may not be completed before the end of this charter period. All work is expected to be
+            incubated in the
+            Immersive Web Community Group first. These deliverables are in rough priority order as of the start of the
+            charter
+            period, although the Chairs may reprioritize based on the consensus of the Working Group during the
+            charter period.</p>
 
-            <br>
-            <p>
-              The Working Group also intends to work on the following Recommendation-Track deliverables, although it
-              recognizes these
-              Recommendations may not be completed before the end of this charter period. All work is expected to be
-              incubated in the
-              Immersive Web Community Group first. These deliverables are in rough priority order as of the start of the
-              charter
-              period, although the Chairs may reprioritize based on the consensus of the Working Group during the
-              charter period.</p>
-
-
+        <dl>
           <dt id="webxr-real-world-geometry" class="spec"><a
               href="https://immersive-web.github.io/real-world-geometry/plane-detection.html">WebXR Real World Geometry
               Module</a></dt>
@@ -474,8 +477,8 @@
                 Real
                 World Geometry Proposal</a></p>
           </dd>
+        </dl>
 
-          <br>
           <p>
             The Working Group also may choose to deliver normative specifications for the following features, if there
             is consensus
@@ -485,7 +488,8 @@
 
           </p>
 
-          <dt id="xr-capture" class="spec"><a href="https://immersive-web.github.io/depth-sensing/">XR Capture
+        <dl>
+          <dt id="xr-capture" class="spec"><a href="https://github.com/immersive-web/proposals/issues/68">XR Capture
               Module</a></dt>
           <dd>
             <p>This feature would enable users to record their AR session directly to the device in a way that is opaque
@@ -493,13 +497,12 @@
               site.</p>
           </dd>
 
-          <dt id="image-detection" class="spec"><a href="https://immersive-web.github.io/depth-sensing/">Image
-              Detection</a></dt>
+          <dt id="image-detection" class="spec">Image Detection</dt>
           <dd>
             <p>This feature would enable access to image detection support on AR devices.</p>
           </dd>
 
-          <dt id="marker-detection" class="spec">Marker Detection</dt>
+          <dt id="marker-detection" class="spec"><a href="https://immersive-web.github.io/marker-tracking/">Marker Detection</a></dt>
           <dd>
             <p>This feature would enable access to QR code marker detection support on AR devices.</p>
           </dd>
@@ -940,9 +943,7 @@
                 1 June 2024
               </td>
               <td>
-                <p>WebXR Gamepads Module, WebXR Augmented Reality Module, WebXR Hit Test Module, WebXR DOM Overlays
-                  Module, WebXR Lighting Estimation Module, WebXR Hand Input Module, WebXR Real World Geometry Module,
-                  WebXR Anchors Module, WebXR Layers</p>
+                <p>Raw Camera Access, Depth/Occlusion API, Navigation</p>
               </td>
             </tr>
           </tbody>

--- a/immersive-web-wg-charter.html
+++ b/immersive-web-wg-charter.html
@@ -262,6 +262,9 @@
                 href="https://www.w3.org/2020/05/immersive-Web-wg-charter.html" target="_blank">Previous charter period
                 of the Immersive
                 Web Working Group</a></p>
+            <p>Exclusion Draft:
+              <a href='https://www.w3.org/TR/2019/WD-webxr-20190205/'>https://www.w3.org/TR/2019/WD-webxr-20190205/</a><br>
+              associated <a href='https://www.w3.org/mid/cfe-6912-27901e8bd54a2a676efc007a2965c637bf272615@w3.org'> Call for Exclusion</a> on 2019-02-05 ended on 2019-07-0</p>
           </dd>
 
           <dt id="webxr-gamepads-module-1" class="spec"><a href="https://immersive-web.github.io/webxr-gamepads-module/"
@@ -282,6 +285,9 @@
                 href="https://www.w3.org/2020/05/immersive-Web-wg-charter.html" target="_blank">Previous charter period
                 of the Immersive
                 Web Working Group</a></p>
+            <p>Exclusion Draft:
+              <a href='https://www.w3.org/TR/2019/WD-webxr-gamepads-module-1-20191010/'>https://www.w3.org/TR/2019/WD-webxr-gamepads-module-1-20191010/</a><br>
+              associated <a href='https://www.w3.org/mid/cfe-7193-cf587ae1c2ebc13c54392174876cc8922874016e@w3.org'> Call for Exclusion</a> on 2019-10-10 ended on 2020-03-08</p>
           </dd>
 
           <dt id="webxr-ar-module-1" class="spec"><a href="https://immersive-web.github.io/webxr-ar-module/"
@@ -302,6 +308,9 @@
             <p>Produced under <b>Working Group Charter:</b> <a
                 href="https://www.w3.org/2020/05/immersive-Web-wg-charter.html">Previous charter period of the Immersive
                 Web Working Group</a></p>
+            <p>Exclusion Draft:
+              <a href='https://www.w3.org/TR/2019/WD-webxr-ar-module-1-20191010/'>https://www.w3.org/TR/2019/WD-webxr-ar-module-1-20191010/</a><br>
+              associated <a href='https://www.w3.org/mid/cfe-7192-052e03bf87b1bc6b5e30c3a2050d3b1ee57a5923@w3.org'> Call for Exclusion</a> on 2019-10-10 ended on 2020-03-08</p>
           </dd>
 
           <dt id="webxr-hit-test" class="spec"><a href="https://immersive-web.github.io/hit-test/" target="_blank">WebXR
@@ -318,6 +327,9 @@
                 target="_blank">WebXR
                 Hit Test
                 Module</a>(31 August 2021)</p>
+            <p>Exclusion Draft:
+              <a href='https://www.w3.org/TR/2021/WD-webxr-hit-test-1-20210831/'>https://www.w3.org/TR/2021/WD-webxr-hit-test-1-20210831/</a><br>
+              associated <a href='https://www.w3.org/mid/cfe-8519-04be7f101f94882ce9ad5bbb5fbcd94ee7315b1c@w3.org'> Call for Exclusion</a> on 2021-08-31 ended on 2022-01-28</p>
           </dd>
 
         </dl>
@@ -333,6 +345,9 @@
             <p><b>Adopted Working Draft:</b> <a href="https://www.w3.org/TR/2021/WD-webxr-dom-overlays-1-20210831/"
                 target="_blank">WebXR DOM Overlays
                 Module</a>(31 August 2021)</p>
+            <p>Exclusion Draft:
+              <a href='https://www.w3.org/TR/2021/WD-webxr-dom-overlays-1-20210831/'>https://www.w3.org/TR/2021/WD-webxr-dom-overlays-1-20210831/</a><br>
+              associated <a href='https://www.w3.org/mid/cfe-8520-c287850e7931cbfa0340f98bf88914a3e09eb696@w3.org'> Call for Exclusion</a> on 2021-08-31 ended on 2022-01-28</p>
           </dd>
 
           <dt id="webxr-lighting-estimation" class="spec"><a href="https://immersive-web.github.io/lighting-estimation/"
@@ -345,6 +360,9 @@
             <p><b>Adopted Working Draft:</b> <a
                 href="https://www.w3.org/TR/2021/WD-webxr-lighting-estimation-1-20210909/" target="_blank">WebXR
                 Lighting Estimation Proposal</a>(9 September 2021)</p>
+            <p>Exclusion Draft:
+              <a href='https://www.w3.org/TR/2021/WD-webxr-lighting-estimation-1-20210909/'>https://www.w3.org/TR/2021/WD-webxr-lighting-estimation-1-20210909/</a><br>
+              associated <a href='https://www.w3.org/mid/cfe-8571-aa44fe0b1d0076df4a491deb7d06b0049d243f3f@w3.org'> Call for Exclusion</a> on 2021-09-09 ended on 2022-02-06</i></p>
           </dd>
 
           <dt id="webxr-hand-input" class="spec"><a href="https://immersive-web.github.io/webxr-hand-input/"
@@ -356,6 +374,9 @@
             <p><b>Adopted Working Draft:</b> <a href="https://www.w3.org/TR/2021/WD-webxr-hand-input-1-20210824/"
                 target="_blank">WebXR Hand
                 Input Proposal</a></p>
+            <p>Exclusion Draft:
+              <a href='https://www.w3.org/TR/2020/WD-webxr-hand-input-1-20201022/'>https://www.w3.org/TR/2020/WD-webxr-hand-input-1-20201022/</a><br>
+              associated <a href='https://www.w3.org/mid/cfe-7623-ef016e129bceabf9aa2b7558bda7d0ce303bde86@w3.org'> Call for Exclusion</a> on 2020-10-22 ended on 2021-03-21</p>
           </dd>
 
           <dt id="webxr-anchors" class="spec"><a href="https://immersive-web.github.io/anchors/">WebXR Anchors
@@ -385,6 +406,9 @@
                 target="_blank">WebXR
                 Layers Proposal</a>
             </p>
+            <p>Exclusion Draft:
+              <a href='https://www.w3.org/TR/2020/WD-webxrlayers-1-20201203/'>https://www.w3.org/TR/2020/WD-webxrlayers-1-20201203/</a><br>
+              associated <a href='https://www.w3.org/mid/cfe-7696-f109199ec21e8eb19e4554ea36ee617b07e5f00d@w3.org'> Call for Exclusion</a> on 2020-12-03 ended on 2021-05-02</p>
           </dd>
         </dl>
 
@@ -404,10 +428,13 @@
               API</a></dt>
           <dd>
             <p>This feature would provide depth and occlusion data on AR devices.</p>
-            <p class="draft-status"><b>Draft state:</b> Adopted from the Immersive Web CG</p>
+            <p class="draft-status"><b>Draft state:</b> Working Draft</p>
             <p class="milestone todo"><b>Expected completion:</b> <i>Q4 2023</i></p>
             <p><b>Adopted Working Draft:</b> <a
                 href="https://www.w3.org/TR/2021/WD-webxr-depth-sensing-1-20210831/">WebXR Depth Sensing Module</a></p>
+            <p>Exclusion Draft:
+              <a href='https://www.w3.org/TR/2021/WD-webxr-depth-sensing-1-20210831/'>https://www.w3.org/TR/2021/WD-webxr-depth-sensing-1-20210831/</a><br>
+              associated <a href='https://www.w3.org/mid/cfe-8518-b1a8b62d07dce7e017068baaa2fb901082738934@w3.org'> Call for Exclusion</a> on 2021-08-31 ended on 2022-01-28</p>
           </dd>
 
           <dt id="spec-navigation" class="spec"><a href="https://github.com/immersive-web/navigation">Navigation</a>


### PR DESCRIPTION
- Added IPP links for ones after FPWD
- aligned module title as ones in draft spec
- Added /TR/ links to draft state lines
- fixed styles for paragraph between lists
- updated history table